### PR TITLE
Add keyboard shortcut option with Ctrl+Shift+F as default

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,15 @@
     "default_title": "Add custom search engine"
   },
 
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+F"
+      },
+      "description": "Add custom search engine"
+    }
+  },
+
   "background": {
     "scripts": ["background.js"]
   },


### PR DESCRIPTION
Only a minor change to manifest.json to allow removing UI button in favor of keyboard shortcut.
Idea is to avoid cluttering UI for relatively rare action, yet not require going through Ctrl+Shift+A and extra clicks there.

Picked Ctrl+Shift+F as default, as it's easy to keep in mind next to Ctrl+F (regular page search), can be changed or disabled by user in about:addons.
Might be worth mentioning the key in AMO addon description, either as a feature or to avoid surprising anyone.

Thanks!