### PR TITLE
Add rel=suggestions to the Url tag for suggestion

### DIFF
--- a/search.js
+++ b/search.js
@@ -71,6 +71,7 @@ function createXMLString() {
   // Suggest URL
   const suggestUrl = doc.querySelector("Url[type=\"application/x-suggestions+json\"]");
   if (data.get("suggest-url")) {
+    suggestUrl.setAttribute("rel", "suggestions");
     suggestUrl.setAttribute("method", "GET");
     suggestUrl.setAttribute("template", data.get("suggest-url"));
   } else {


### PR DESCRIPTION
I noticed suggestion doesn't work despite I fill "Suggest URL" field, like "https://www.google.com/complete/search?gl=us&output=firefox&q={searchTerms}".

Adding `rel="suggestions"` attribute to the `<Url >` tag resolved the issue, so seems the attribute is necessary(at least for Firefox 99). This PR adds it.

Reference: [Google Official OpenSearch File](https://www.google.com/searchdomaincheck?format=opensearch)